### PR TITLE
Fixed json-read-from-string not being defined at compile time

### DIFF
--- a/neon-mode.el
+++ b/neon-mode.el
@@ -1,4 +1,4 @@
-;;; neon-mode.el --- Simple major mode for editing neon files
+;;; neon-mode.el --- Simple major mode for editing neon files  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2015-2017 Matúš Goljer <matus.goljer@gmail.com>
 
@@ -7,6 +7,7 @@
 ;; Version: 1.1.0
 ;; Created: 26th March 2015
 ;; Keywords: conf
+;; Package-Requires: ((emacs "24.1"))
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU General Public License
@@ -34,10 +35,15 @@
 (require 'thingatpt)
 (require 'json)
 
+(defgroup neon ()
+  "Major mode for editing neon files."
+  :group 'languages)
+
 (defcustom neon-mode-find-project-root-function (if (featurep 'projectile)
                                                     'projectile-project-root
                                                   'neon-mode--project-root-by-composer)
   "Function to detect the project root."
+  :group 'neon
   :type '(choice (const :tag "Use Projectile's project root detection" projectile-project-root)
                  (const :tag "Detect project root by composer.json presence" neon-mode--project-root-by-composer)
                  (function :tag "Use custom function")))
@@ -55,7 +61,7 @@ Uses `neon-mode-find-project-root-function' todo the actual lookup."
   (funcall neon-mode-find-project-root-function))
 
 (defun neon-mode-find-class-file (class)
-  "Find class at point.
+  "Find CLASS at point.
 
 This requires php binary to be present on the system and also
 only works for projects using composer autoloading."

--- a/neon-mode.el
+++ b/neon-mode.el
@@ -32,6 +32,7 @@
 
 (require 'conf-mode)
 (require 'thingatpt)
+(require 'json)
 
 (defcustom neon-mode-find-project-root-function (if (featurep 'projectile)
                                                     'projectile-project-root


### PR DESCRIPTION
The following error occurs in Emacs 30:

```
⛔ Warning (native-compiler): ~/.emacs.d/elpa/neon-mode-20180406.1156/neon-mode.el:80:24: Warning: the function ‘json-read-from-string’ is not known to be defined.
```

```
neon-mode.el:1:1: Warning: file has no ‘lexical-binding’ directive on its
    first line
neon-mode.el:37:12: Warning: in defcustom for
    ‘neon-mode-find-project-root-function’: fails to specify containing
    group
```